### PR TITLE
add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+sudo: false
+
+services:
+  - docker
+
+go:
+  - "1.11.5"
+
+env:
+  - TARGET=docker
+
+script: make $TARGET

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: help
+help:
+	@echo "Targets:"
+	@echo "  docker       -- try to build the docker container"
+
+.PHONY: docker
+docker:
+	docker build . -f Dockerfile


### PR DESCRIPTION
Configure travis job to run a docker build, using a
Makefile to make it easier for developers to run the same tests
locally.