### PR TITLE
Add iproute and python-hardware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - current && \
     yum update -y && \
-    yum install -y openstack-ironic-python-agent lshw smartmontools && \
+    yum install -y openstack-ironic-python-agent lshw smartmontools iproute python-hardware && \
     yum clean all
 
 # NOTE(TheJulia/juliakreger): this command defaults to using multicast


### PR DESCRIPTION
IPA needs a few more commands in order to
collect more complete pictures about the machines.

iproute for networking information and python-hardware
for the extra-hardware data.