### PR TITLE
 Add missing packages to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/centos:centos7
 RUN yum install -y python-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/tripleo_repos/main.py | python - -b train current-tripleo && \
     yum update -y && \
-    yum install -y openstack-ironic-python-agent lshw smartmontools iproute python-hardware && \
+    yum install -y openstack-ironic-python-agent lshw smartmontools iproute python-hardware mdadm biosdevname ipmitool && \
     yum clean all
 
 COPY ./runironic-agent.sh /bin/runironic-agent

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ transmitted to an attached ironic-inspector instance.
 
 The ironic-inspector is service located via mdns name
 *baremetal-introspection._openstack._tcp.local.*
+
+Run the container using the `--privileged --network=host -v /dev:/dev` options.


### PR DESCRIPTION
Add packages "mdadm", "biosdevname" and "ipmitool" to the image to
make the container independent from the host.

Update the README with the options necessary to run the container.