### PR TITLE
Move base image to CentOS 8 Stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker.io/centos:centos8
+FROM quay.io/centos/centos:stream8
 
 RUN dnf install -y python3 python3-requests && \
-    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master --no-stream current-tripleo && \
+    curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf upgrade -y && \
     dnf install -y openstack-ironic-python-agent lshw smartmontools \
       iproute python3-hardware-detect mdadm biosdevname ipmitool && \


### PR DESCRIPTION
EOL for CentOS 8 was end of 2021 and the build fails to repository
issues. Rather than working around these, move the base image to
CentOS 8 Stream.