### PR TITLE
Add URL_CALLBACK to provide the whole callback URL

### DIFF
--- a/runironic-agent.sh
+++ b/runironic-agent.sh
@@ -2,11 +2,14 @@
 
 IRONIC_INSPECTOR_IP=${IRONIC_INSPECTOR_IP:-"mdns"}
 IRONIC_INSPECTOR_PORT=${IRONIC_INSPECTOR_PORT:-"5050"}
+URL_CALLBACK=${URL_CALLBACK:-""}
 
-if [[ ${IRONIC_INSPECTOR_IP} == "mdns" ]]; then
-    URL_CALLBACK=${IRONIC_INSPECTOR_IP}
-else
-    URL_CALLBACK="http://${IRONIC_INSPECTOR_IP}:${IRONIC_INSPECTOR_PORT}/v1/continue"
+if [ -z "${URL_CALLBACK}" ]; then
+    if [[ ${IRONIC_INSPECTOR_IP} == "mdns" ]]; then
+        URL_CALLBACK=${IRONIC_INSPECTOR_IP}
+    else
+        URL_CALLBACK="http://${IRONIC_INSPECTOR_IP}:${IRONIC_INSPECTOR_PORT}/v1/continue"
+    fi
 fi
 
 exec /usr/bin/ironic-collect-introspection-data \


### PR DESCRIPTION
If mdns is not used and the IP address (which uses http at the
moment) is not flexible enough, allow to specify a full callback URL.