### PR TITLE
update user-guide url

### DIFF
--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -7,5 +7,5 @@ Please do:
 
 In this repository security reports are handled according to the
 Metal3-io project's security policy. For more information about the security
-policy consult the User-Guide [here](https://metal3io.netlify.app/security_policy.html).
+policy consult the User-Guide [here](https://book.metal3.io/security_policy.html).
 


### PR DESCRIPTION
Our user-guide is now properly hosted at https://book.metal3.io/