### PR TITLE
add OWNERS_ALIASES support

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
- - bfournie
- - derekhiggins
- - dtantsur
- - elfosardo
- - kashifest
+- ironic-hardware-inventory-recorder-image-maintainers
 
 reviewers:
- - iurygregory
- - Rozzii
- - stbenjam
- - zaneb
+- ironic-hardware-inventory-recorder-image-maintainers
+- ironic-hardware-inventory-recorder-image-reviewers
 
 emeritus_approvers:
- - hardys
+- hardys
 
 emeritus_reviewers:
- - maelk
+- maelk

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+aliases:
+  ironic-hardware-inventory-recorder-image-maintainers:
+  - bfournie
+  - derekhiggins
+  - dtantsur
+  - elfosardo
+  - kashifest
+
+  ironic-hardware-inventory-recorder-image-reviewers:
+  - iurygregory
+  - Rozzii
+  - stbenjam
+  - zaneb


### PR DESCRIPTION
OWNERS_ALIASES groups are needed for fair blunderbuss review requests.