### PR TITLE
:seedling: add labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
 FROM $BASE_IMAGE
 
+# image.version is set during image build by automation
+LABEL org.opencontainers.image.authors="metal3-dev@googlegroups.com"
+LABEL org.opencontainers.image.description="Container image to run Ironic HW Inventory Recorder as part of Metal³"
+LABEL org.opencontainers.image.documentation="https://github.com/metal3-io/ironic-hardware-inventory-recorder-image"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL org.opencontainers.image.title="Metal3 Ironic HW Inventory Recorder"
+LABEL org.opencontainers.image.url="https://github.com/metal3-io/ironic-hardware-inventory-recorder-image"
+LABEL org.opencontainers.image.vendor="Metal3-io"
+
 RUN dnf install -y python3 python3-requests && \
     curl https://raw.githubusercontent.com/openstack/tripleo-repos/master/plugins/module_utils/tripleo_repos/main.py | python3 - -b master current-tripleo && \
     dnf upgrade -y && \
@@ -13,4 +22,3 @@ RUN dnf install -y python3 python3-requests && \
 COPY ./runironic-agent.sh /bin/runironic-agent
 
 ENTRYPOINT ["/bin/runironic-agent"]
-


### PR DESCRIPTION
Add org.opencontainers labels to Dockerfile.  `image.version` will be set by build automation.